### PR TITLE
Support building for win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
+find_package(kodiplatform REQUIRED)
 
 add_subdirectory(lib/nosefart)
 
-include_directories(${KODI_INCLUDE_DIR}
+include_directories(${kodiplatform_INCLUDE_DIRS}
+                    ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/lib/nosefart/src)
 
 set(NOSEFART_SOURCES src/NSFCodec.cpp)
 
-set(DEPLIBS nosefart)
+set(DEPLIBS ${kodiplatform_LIBRARIES} nosefart)
 
 build_addon(audiodecoder.nosefart NOSEFART DEPLIBS)
 

--- a/audiodecoder.nosefart/addon.xml
+++ b/audiodecoder.nosefart/addon.xml
@@ -13,7 +13,11 @@
     tags="true"
     tracks="true"
     extension=".nsf|.nsfstream"
-    library_linux="audiodecoder.nosefart.so"/>
+    library_linux="audiodecoder.nosefart.so"
+    library_osx="audiodecoder.nosefart.dylib"
+    library_freebsd="audiodecoder.nosefart.so"
+    library_windx="audiodecoder.nosefart.dll"
+    library_android="libaudiodecoder.nosefart.so"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Nosefart (NSF) Audio Decoder</summary>
     <description lang="en">Nosefart (NSF) Audio Decoder</description>

--- a/src/NSFCodec.cpp
+++ b/src/NSFCodec.cpp
@@ -18,6 +18,9 @@
  *
  */
 
+#include <algorithm>
+#include <string>
+
 #include "kodi/libXBMC_addon.h"
 
 extern "C" {


### PR DESCRIPTION
Apart from the usual changes (kodi-platform and addon.xml) I had two add the `<algorithm>` include for `std::min`. While at it I also added the `<string>` include.