### PR TITLE
fix array overflow

### DIFF
--- a/lib/nosefart/src/sndhrdw/fmopl.c
+++ b/lib/nosefart/src/sndhrdw/fmopl.c
@@ -570,7 +570,7 @@ static void init_timetables( FM_OPL *OPL , int ARRATE , int DRRATE )
 		OPL->AR_TABLE[i] = (INT32) (rate / ARRATE);
 		OPL->DR_TABLE[i] = (INT32) (rate / DRRATE);
 	}
-	for (i = 60;i < 76;i++)
+	for (i = 60;i < 75;i++)
 	{
 		OPL->AR_TABLE[i] = EG_AED-1;
 		OPL->DR_TABLE[i] = OPL->DR_TABLE[60];


### PR DESCRIPTION
DR_TABLE and AR_TABLE have just 75 elements.

Signed-off-by: Olaf Hering <olaf@aepfle.de>