### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 
 add_subdirectory(lib/nosefart)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/..
+include_directories(${KODI_INCLUDE_DIR}/..
                     ${PROJECT_SOURCE_DIR}/lib/nosefart/src)
 
 set(NOSEFART_SOURCES src/NSFCodec.cpp)

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: kodi-audiodecoder-nosefart
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev (>= 16.0.0)
+Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.nosefart binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.