### PR TITLE
apu_setcontext not defined in header

### DIFF
--- a/lib/nosefart/src/cpu/nes6502/nes6502.c
+++ b/lib/nosefart/src/cpu/nes6502/nes6502.c
@@ -28,6 +28,7 @@
 #include "nes6502.h"
 #include "dis6502.h"
 #include <stdio.h>
+#include <string.h>
 
 
 #define  ADD_CYCLES(x)     instruction_cycles += (x)

--- a/lib/nosefart/src/sndhrdw/nes_apu.h
+++ b/lib/nosefart/src/sndhrdw/nes_apu.h
@@ -282,6 +282,7 @@ extern void apu_reset(void);
 extern int apu_setchan(int chan, boolean enabled);
 extern int32 apu_getcyclerate(void);
 extern apu_t *apu_getcontext(void);
+extern void apu_setcontext(apu_t *src_apu);
 
 extern uint8 apu_read(uint32 address);
 extern void apu_write(uint32 address, uint8 value);


### PR DESCRIPTION
Missing declaration void apu_setcontext(apu_t *src_apu)

Should fix build failure
```
/Users/Shared/jenkins/workspace/TVOS/tools/depends/target/binary-addons/appletvos13.2_arm64-target-release/build/audiodecoder.nosefart/lib/nosefart/src/machine/nsf.c:327:5: error: implicit declaration of function 'apu_setcontext' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
     apu_setcontext(nsf->apu);
```

Upstream seems to be a giant mess. Finding all sorts of things forked, so no idea where to upstream this. But seeing the esp32 company espressif shipping the following makes me feel safe someone has just butchered the header and not put in the setcontext 

https://github.com/espressif/esp32-nesemu/blob/693e378643dd4810665e52c0ec02bd9f64559c50/components/nofrendo/sndhrdw/nes_apu.h#L236-L237

Looks like there was another issue. Missing header include for memset

```
/Users/Shared/jenkins/workspace/binary-addons/kodi-tvos-aarch64-Matrix/tools/depends/target/binary-addons/audiodecoder.nosefart/lib/nosefart/src/cpu/nes6502/nes6502.c:2515:4: error: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Werror,-Wimplicit-function-declaration]

   memset(acc_nes6502_banks, 0, NES6502_NUMBANKS);
   ^
```